### PR TITLE
release: v1.0.69

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "wp-content-framework/admin",
-            "version": "v1.0.66",
+            "version": "v1.0.67",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/admin.git",
-                "reference": "3d209a5144ba64f297294f4184f6c619491ea511"
+                "reference": "78b0a8d9f3601afe62f403756799ed2d11f99182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/admin/zipball/3d209a5144ba64f297294f4184f6c619491ea511",
-                "reference": "3d209a5144ba64f297294f4184f6c619491ea511",
+                "url": "https://api.github.com/repos/wp-content-framework/admin/zipball/78b0a8d9f3601afe62f403756799ed2d11f99182",
+                "reference": "78b0a8d9f3601afe62f403756799ed2d11f99182",
                 "shasum": ""
             },
             "require": {
@@ -183,7 +183,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/admin/issues",
-                "source": "https://github.com/wp-content-framework/admin/tree/v1.0.66"
+                "source": "https://github.com/wp-content-framework/admin/tree/v1.0.67"
             },
             "funding": [
                 {
@@ -191,20 +191,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-07-21T07:17:35+00:00"
+            "time": "2021-07-30T08:59:42+00:00"
         },
         {
             "name": "wp-content-framework/controller",
-            "version": "v1.0.62",
+            "version": "v1.0.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/controller.git",
-                "reference": "2e55ffebb941907c844cfc604406be77c2be05fd"
+                "reference": "c69826b17907298706881f911b4f81386c9dd0c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/controller/zipball/2e55ffebb941907c844cfc604406be77c2be05fd",
-                "reference": "2e55ffebb941907c844cfc604406be77c2be05fd",
+                "url": "https://api.github.com/repos/wp-content-framework/controller/zipball/c69826b17907298706881f911b4f81386c9dd0c7",
+                "reference": "c69826b17907298706881f911b4f81386c9dd0c7",
                 "shasum": ""
             },
             "require": {
@@ -238,7 +238,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/controller/issues",
-                "source": "https://github.com/wp-content-framework/controller/tree/v1.0.62"
+                "source": "https://github.com/wp-content-framework/controller/tree/v1.0.63"
             },
             "funding": [
                 {
@@ -246,20 +246,20 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-07-10T14:17:22+00:00"
+            "time": "2021-07-26T14:08:05+00:00"
         },
         {
             "name": "wp-content-framework/presenter",
-            "version": "v1.0.50",
+            "version": "v1.0.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/presenter.git",
-                "reference": "07800e214654c1be93cc48ca36317c6edb94a6b7"
+                "reference": "108448fa264c1d1cd1d8d760dda2c69338b73473"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/07800e214654c1be93cc48ca36317c6edb94a6b7",
-                "reference": "07800e214654c1be93cc48ca36317c6edb94a6b7",
+                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/108448fa264c1d1cd1d8d760dda2c69338b73473",
+                "reference": "108448fa264c1d1cd1d8d760dda2c69338b73473",
                 "shasum": ""
             },
             "require": {
@@ -293,7 +293,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/presenter/issues",
-                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.50"
+                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.51"
             },
             "funding": [
                 {
@@ -301,7 +301,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-07-05T06:07:24+00:00"
+            "time": "2021-07-26T14:07:44+00:00"
         },
         {
             "name": "wp-content-framework/view",
@@ -362,21 +362,21 @@
     "packages-dev": [
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
-                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/84674dd3a7575ba617f5a76d7e9e29a7d3891339",
+                "reference": "84674dd3a7575ba617f5a76d7e9e29a7d3891339",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "require-dev": {
                 "phpstan/phpstan": "^0.12.55",
@@ -406,7 +406,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.2"
             },
             "funding": [
                 {
@@ -422,7 +422,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-05T19:37:51+00:00"
+            "time": "2021-07-31T17:03:58+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -856,30 +856,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -900,9 +900,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -962,16 +962,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.3.3",
+            "version": "v5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "a69e0c55528b47df88d3c4067ddedf32d485d662"
+                "reference": "4268f3059c904c61636275182707f81645517a37"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/a69e0c55528b47df88d3c4067ddedf32d485d662",
-                "reference": "a69e0c55528b47df88d3c4067ddedf32d485d662",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4268f3059c904c61636275182707f81645517a37",
+                "reference": "4268f3059c904c61636275182707f81645517a37",
                 "shasum": ""
             },
             "require": {
@@ -979,7 +979,7 @@
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/filesystem": "^4.4|^5.0",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/polyfill-php81": "^1.22"
             },
             "conflict": {
@@ -1021,7 +1021,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.3.3"
+                "source": "https://github.com/symfony/config/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -1037,27 +1037,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-24T08:13:00+00:00"
+            "time": "2021-07-21T12:40:44+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.3.3",
+            "version": "v5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "e421c4f161848740ad1fcf09b12391ddca168d95"
+                "reference": "5a825e4b386066167a8b55487091cb62beec74c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e421c4f161848740ad1fcf09b12391ddca168d95",
-                "reference": "e421c4f161848740ad1fcf09b12391ddca168d95",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5a825e4b386066167a8b55487091cb62beec74c2",
+                "reference": "5a825e4b386066167a8b55487091cb62beec74c2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "psr/container": "^1.1.1",
                 "symfony/deprecation-contracts": "^2.1",
-                "symfony/polyfill-php80": "^1.15",
+                "symfony/polyfill-php80": "^1.16",
                 "symfony/service-contracts": "^1.1.6|^2"
             },
             "conflict": {
@@ -1109,7 +1109,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.3.3"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -1125,7 +1125,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-24T08:13:00+00:00"
+            "time": "2021-07-23T15:55:36+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1196,21 +1196,22 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.3.3",
+            "version": "v5.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "19b71c8f313b411172dd5f470fd61f24466d79a9"
+                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/19b71c8f313b411172dd5f470fd61f24466d79a9",
-                "reference": "19b71c8f313b411172dd5f470fd61f24466d79a9",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/343f4fe324383ca46792cae728a3b6e2f708fb32",
+                "reference": "343f4fe324383ca46792cae728a3b6e2f708fb32",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8"
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -1238,7 +1239,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.3.3"
+                "source": "https://github.com/symfony/filesystem/tree/v5.3.4"
             },
             "funding": [
                 {
@@ -1254,7 +1255,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-30T07:27:52+00:00"
+            "time": "2021-07-21T12:40:44+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1337,16 +1338,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
                 "shasum": ""
             },
             "require": {
@@ -1400,7 +1401,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -1416,7 +1417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-07-28T13:41:28+00:00"
         },
         {
             "name": "symfony/polyfill-php81",

--- a/composer.lock
+++ b/composer.lock
@@ -1041,16 +1041,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.3.4",
+            "version": "v5.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "5a825e4b386066167a8b55487091cb62beec74c2"
+                "reference": "a665946279f566d94ed5eb98999cfa65c6fa5a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/5a825e4b386066167a8b55487091cb62beec74c2",
-                "reference": "5a825e4b386066167a8b55487091cb62beec74c2",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a665946279f566d94ed5eb98999cfa65c6fa5a78",
+                "reference": "a665946279f566d94ed5eb98999cfa65c6fa5a78",
                 "shasum": ""
             },
             "require": {
@@ -1109,7 +1109,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.3.4"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.3.7"
             },
             "funding": [
                 {
@@ -1125,7 +1125,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-23T15:55:36+00:00"
+            "time": "2021-08-02T16:16:27+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (a4e047b263c18bb082c54f29bc67988d93a931b9, 00321c1eee367a62afc0aa9cb022e5549e042db5)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/test/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.10 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 25 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (2.0.2)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.10.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.2)
  - Locking phpmd/phpmd (2.10.2)
  - Locking psr/container (1.1.1)
  - Locking psr/log (3.0.0)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.3.4)
  - Locking symfony/dependency-injection (v5.3.4)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/filesystem (v5.3.4)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.1)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/admin (v1.0.67)
  - Locking wp-content-framework/controller (v1.0.63)
  - Locking wp-content-framework/presenter (v1.0.51)
  - Locking wp-content-framework/view (v1.0.62)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 25 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.6.0)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading matthiasmullie/minify (1.3.66)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.2)
  - Downloading symfony/polyfill-php80 (v1.23.1)
  - Downloading symfony/polyfill-ctype (v1.23.0)
  - Downloading symfony/filesystem (v5.3.4)
  - Downloading psr/container (1.1.1)
  - Downloading symfony/service-contracts (v2.4.0)
  - Downloading symfony/deprecation-contracts (v2.4.0)
  - Downloading symfony/dependency-injection (v5.3.4)
  - Downloading symfony/polyfill-php81 (v1.23.0)
  - Downloading symfony/config (v5.3.4)
  - Downloading pdepend/pdepend (2.10.0)
  - Downloading psr/log (3.0.0)
  - Downloading composer/xdebug-handler (2.0.2)
  - Downloading phpmd/phpmd (2.10.2)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading wp-content-framework/presenter (v1.0.51)
  - Downloading wp-content-framework/view (v1.0.62)
  - Downloading wp-content-framework/controller (v1.0.63)
  - Downloading wp-content-framework/admin (v1.0.67)
  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.2): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v5.3.4): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/dependency-injection (v5.3.4): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/config (v5.3.4): Extracting archive
  - Installing pdepend/pdepend (2.10.0): Extracting archive
  - Installing psr/log (3.0.0): Extracting archive
  - Installing composer/xdebug-handler (2.0.2): Extracting archive
  - Installing phpmd/phpmd (2.10.2): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.51): Extracting archive
  - Installing wp-content-framework/view (v1.0.62): Extracting archive
  - Installing wp-content-framework/controller (v1.0.63): Extracting archive
  - Installing wp-content-framework/admin (v1.0.67): Extracting archive
9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/admin
./composer.json has been updated
Running composer update wp-content-framework/admin
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.10 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 25 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (2.0.2)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.10.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.2)
  - Locking phpmd/phpmd (2.10.2)
  - Locking psr/container (1.1.1)
  - Locking psr/log (3.0.0)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.3.4)
  - Locking symfony/dependency-injection (v5.3.4)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/filesystem (v5.3.4)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.1)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/admin (v1.0.67)
  - Locking wp-content-framework/controller (v1.0.63)
  - Locking wp-content-framework/presenter (v1.0.51)
  - Locking wp-content-framework/view (v1.0.62)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 25 installs, 0 updates, 0 removals
  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.2): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v5.3.4): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/dependency-injection (v5.3.4): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/config (v5.3.4): Extracting archive
  - Installing pdepend/pdepend (2.10.0): Extracting archive
  - Installing psr/log (3.0.0): Extracting archive
  - Installing composer/xdebug-handler (2.0.2): Extracting archive
  - Installing phpmd/phpmd (2.10.2): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.51): Extracting archive
  - Installing wp-content-framework/view (v1.0.62): Extracting archive
  - Installing wp-content-framework/controller (v1.0.63): Extracting archive
  - Installing wp-content-framework/admin (v1.0.67): Extracting archive
9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/admin
./composer.json has been updated
Running composer update wp-content-framework/admin
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
16 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)